### PR TITLE
Fix references to docker-compose in comments

### DIFF
--- a/src/assessor_portal.yml
+++ b/src/assessor_portal.yml
@@ -16,6 +16,10 @@
           ansible.builtin.command:
             chdir: "{{ assessor_portal_dir }}"
             cmd: "{{ assessor_portal_dir }}/run.py pull"
+        # The community.docker.docker_compose module exists, but it
+        # only supports docker-compose and not the Docker compose
+        # plugin (i.e., docker compose).  Ansible may offer more
+        # up-to-date support for Docker compositions in the future.
         - name: Pull images from Assessor Portal docker-compose.yml
           ansible.builtin.command:
             chdir: "{{ assessor_portal_dir }}"

--- a/src/assessor_portal.yml
+++ b/src/assessor_portal.yml
@@ -17,7 +17,7 @@
             chdir: "{{ assessor_portal_dir }}"
             cmd: "{{ assessor_portal_dir }}/run.py pull"
         # The community.docker.docker_compose module exists, but it
-        # only supports docker-compose and not the Docker compose
+        # only supports docker-compose and not the Docker Compose
         # plugin (i.e., docker compose).  Ansible may offer more
         # up-to-date support for Docker compositions in the future.
         - name: Pull images from Assessor Portal docker-compose.yml

--- a/src/assessor_portal.yml
+++ b/src/assessor_portal.yml
@@ -56,7 +56,7 @@
             owner: "{{ vnc_username }}"
             group: "{{ vnc_username }}"
     # Add VNC user to docker group so that operators can successfully
-    # execute docker-compose commands.
+    # execute docker compose commands.
     - name: Add VNC user to docker group
       ansible.builtin.user:
         append: yes

--- a/src/assessor_portal.yml
+++ b/src/assessor_portal.yml
@@ -17,9 +17,9 @@
             chdir: "{{ assessor_portal_dir }}"
             cmd: "{{ assessor_portal_dir }}/run.py pull"
         - name: Pull images from Assessor Portal docker-compose.yml
-          community.docker.docker_compose:
-            project_src: "{{ assessor_portal_dir }}"
-            pull: yes
+          ansible.builtin.command:
+            chdir: "{{ assessor_portal_dir }}"
+            cmd: docker compose pull
     # We use cloud-init scripts in cisagov/cool-assessment-terraform to
     # set Docker's backing file system to a persistent volume.  It would
     # cause problems if the Docker service were to start before cloud-init

--- a/src/extras.yml
+++ b/src/extras.yml
@@ -11,7 +11,7 @@
           - dnsutils
           - firefox-esr
     # Add VNC user to docker group so that operators can
-    # successfully execute docker-compose commands.
+    # successfully execute docker compose commands.
     - name: Add VNC user to docker group
       ansible.builtin.user:
         append: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates this repository to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.